### PR TITLE
fix: adapt rule to not have false positives for content type pdf

### DIFF
--- a/tests/110-MUST-always-return-JSON-objects-as-top-level-data-structures.test.ts
+++ b/tests/110-MUST-always-return-JSON-objects-as-top-level-data-structures.test.ts
@@ -19,7 +19,6 @@ function addResponseContent(openApiSpec: OpenApiSpec, contentType: string): Open
 }
 
 describe('MUST always return JSON objects as top-level data structures [110]', () => {
-
   test('Validate json content type', async () => {
     let openApiSpec = await loadOpenApiSpec('base-openapi.yml');
     openApiSpec = addResponseContent(openApiSpec, 'application/json');
@@ -33,7 +32,6 @@ describe('MUST always return JSON objects as top-level data structures [110]', (
       }),
     ]);
   });
-
 
   test('Validate specific content type', async () => {
     let openApiSpec = await loadOpenApiSpec('base-openapi.yml');

--- a/zalando.yml
+++ b/zalando.yml
@@ -15,13 +15,13 @@ rules:
 
   # MUST always return JSON objects as top-level data structures [110]
   # => https://opensource.zalando.com/restful-api-guidelines/#110
-
   must-always-return-json-objects-as-top-level-data-structures:
     message: 'Top-level data structure must be an object'
     description: MUST always return JSON objects as top-level data structures [110]
     documentationUrl: https://opensource.zalando.com/restful-api-guidelines/#110
     severity: error
-    given: $.paths.*.*[responses,requestBody]..content..schema
+    # Only target JSON content types using a more specific JSONPath
+    given: $.paths.*.*[responses,requestBody]..content['application/json'].schema
     then:
       function: is-object-schema
 

--- a/zalando.yml
+++ b/zalando.yml
@@ -21,7 +21,7 @@ rules:
     documentationUrl: https://opensource.zalando.com/restful-api-guidelines/#110
     severity: error
     # Only target JSON content types using a more specific JSONPath
-    given: $.paths.*.*[responses,requestBody]..content['application/json'].schema
+    given: "$.paths.*.*[responses,requestBody]..content[?(@property.match(/^application\\/([a-zA-Z0-9._-]+\\+)?json(;.*)?$/))]..schema"
     then:
       function: is-object-schema
 


### PR DESCRIPTION
**Problem**
The current Spectral rule must-always-return-json-objects-as-top-level-data-structures fails when checking endpoints that return non-JSON content types (such as application/pdf). The rule was incorrectly validating all response schemas regardless of content type.

**Solution**
Modified the rule's JSONPath expression to only target JSON content types, leaving other media types untouched:

JSON responses are still validated to have objects as top-level data structures
Non-JSON responses (PDF, XML, etc.) are excluded from this validation
